### PR TITLE
Update syscalls.nim

### DIFF
--- a/syscalls.nim
+++ b/syscalls.nim
@@ -3,12 +3,7 @@
 
 proc GetTEBAsm64(): LPVOID {.asmNoStackFrame.} =
     asm """
-	push rbx
-    xor rbx, rbx
-    xor rax, rax
-    mov rbx, qword ptr gs:[0x30]
-	mov rax, rbx
-	pop rbx
+        mov rax, qword ptr gs:[0x30]
 	ret
     """
 


### PR DESCRIPTION
In 64-bit mode when operating on 64-bit or 32-bit registers (e.g., EAX and RAX), their values are cleaned before the execution of the instruction. Finally, you don't need 2 general purpose registers because you are only saving one information (i.e., pointer to a structure in mmeory).